### PR TITLE
feat: Addition of virtual machine running the iso provided by the school

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.idea
+.vagrant
+*.iso

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,27 @@
+machine_name = "darkly"
+vm_memory = 2048
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "oraclelinux/9"
+  config.vm.box_url = "https://oracle.github.io/vagrant-projects/boxes/oraclelinux/9.json"
+
+  config.vm.network "public_network", bridge: "en0: Wi-Fi (AirPort)"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.define machine_name do |control|
+      control.vm.hostname = machine_name
+      control.vm.provider "virtualbox" do |vb|
+          vb.memory = vm_memory
+          vb.cpus = 1
+          vb.gui = true
+          vb.name = machine_name
+          vb.linked_clone = true
+          vb.customize ["modifyvm", :id, "--name", machine_name]
+          # Mount iso image
+          vb.customize ["storageattach", :id, "--storagectl", "IDE Controller", \
+          "--port", 1, "--device", 0, "--type", "dvddrive", "--medium", \
+          "#{File.expand_path(".", Dir.pwd)}/Darkly_i386.iso"]
+          # Boot from iso image mounted
+          vb.customize ["modifyvm", :id, "--boot1", "dvd"]
+        end
+    end
+end


### PR DESCRIPTION
It is necessary to add the Darkly_i386.iso file in the vagrant folder.

Oracle vagrant boxes: https://yum.oracle.com/boxes/